### PR TITLE
Fix typo in deprecated finder

### DIFF
--- a/tools/find_deprecated.py
+++ b/tools/find_deprecated.py
@@ -236,7 +236,7 @@ def main():
         print('Unable to import nltk -- check your PYTHONPATH.')
         sys.exit(-1)
 
-    print('Finding definitions of deprecated funtions & classes in nltk...')
+    print('Finding definitions of deprecated functions & classes in nltk...')
     find_deprecated_defs(nltk.__path__[0])
 
     print('Looking for possible uses of deprecated funcs & classes...')


### PR DESCRIPTION
## Summary
- correct spelling of 'functions' in tools/find_deprecated.py

## Testing
- `pre-commit` *(fails: command not found)*